### PR TITLE
Upcoming meeting display on home page

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -7,4 +7,9 @@ class Meeting
     meetings = get("/events?group_id=1460552&fields=name&key=#{ENV.fetch('MEETUP_API_KEY')}")
     meetings["results"].select { |m| m["name"] == "Ruby Brigade" }.first
   end
+
+  def self.get_upcoming_meetings
+    meetings = get("/events?group_id=1460552&fields=name&key=#{ENV.fetch('MEETUP_API_KEY')}")
+    meetings["results"].select { |m| m["name"] == "Ruby Brigade" }.slice(1,3)
+  end
 end

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -30,27 +30,16 @@
     #events.four.columns
       %h3 Upcoming Events
       %section
-        %article
-          .date
-            %h1
-              May
-              %span 15
-          %p Double Rainbow Testing with JRuby and RSpec-given
-          %a{:href => "http://goo.gl/BwcH2", :target => "_blank"} @ Gaslight Studios
-        %article
-          .date
-            %h1
-              May
-              %span 15
-          %p Double Rainbow Testing with JRuby and RSpec-given
-          %a{:href => "http://goo.gl/BwcH2", :target => "_blank"} @ Gaslight Studios
-        %article
-          .date
-            %h1
-              May
-              %span 15
-          %p Double Rainbow Testing with JRuby and RSpec-given
-          %a{:href => "http://goo.gl/BwcH2", :target => "_blank"} @ Gaslight Studios
+        - Meeting.get_upcoming_meetings.each do |meeting|
+          %article
+            .date
+              %h1
+                = Time.at(meeting["time"]/1000).to_date.strftime("%b")
+                %span
+                  = Time.at(meeting["time"]/1000).to_date.strftime("%e")
+            %p
+              = meeting["name"]
+            %a{:href => "http://goo.gl/BwcH2", :target => "_blank"} @ Gaslight Studios
   / end .row
 %section#contact
   .container.row
@@ -59,13 +48,13 @@
     %form.container.row
       #left-contact.five.columns
         %input{:placeholder => "​Name", :type => "​text"}
-        ​
+
         %input{:placeholder => "​Email Address", :type => "​text"}
-        ​
+
         %input{:placeholder => "​Subject", :type => "​\"text"}
-        ​
+
       #left-contact.seven.columns
         %textarea{:id => "​standardTexted", :placeholder => "​Message"}
-        ​
+
       #submit
         %input{:type => "submit", :value => "Submit"}/


### PR DESCRIPTION
For issue #2.  This may be a bit premature, since the titles/descriptions on the upcoming events aren't really interesting, but it's probably better than having three events on May 15.

I wasn't sure how to mock the response from Meetup, so there are no tests.  I _think_ we'd need to construct the Meeting model a little differently to make it easier to mock.

Happy to tweak away, just let me know.

<!---
@huboard:{"order":1.0}
-->
